### PR TITLE
fix: fix 8852be-dkms compilation error

### DIFF
--- a/templates/mod/packages/categories/core.libjsonnet
+++ b/templates/mod/packages/categories/core.libjsonnet
@@ -62,7 +62,7 @@ else
 
                 APT_CONFIG="$MMDEBSTRAP_APT_CONFIG" \
                 apt-get install -oDPkg::Chroot-Directory="$1" -y \
-                radxa-bootutils python-is-python3
+                radxa-bootutils python-is-python3 bc
 
                 APT_CONFIG="$MMDEBSTRAP_APT_CONFIG" \
                 apt-get install -oDPkg::Chroot-Directory="$1" -y \


### PR DESCRIPTION
是编译时缺少依赖bc
```bash
vscode ➜ /workspaces/rsdk (main) $ cat /tmp/mmdebstrap.3mWc0bPtyJ/var/lib/dkms/8852be/1.15.10.0.5.0-3/build/make.log
DKMS make.log for 8852be-1.15.10.0.5.0-3 for kernel 5.10.160-30-rk356x (aarch64)
Fri Mar 29 02:59:57 UTC 2024
make: Entering directory '/usr/src/linux-headers-5.10.160-30-rk356x'
/bin/sh: 1: bc: not found
```