### PR TITLE
fix: ci: move the Chinese html page to right path

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,8 @@ jobs:
             MDBOOK_BOOK__LANGUAGE=$po_lang \
             MDBOOK_OUTPUT__HTML__SITE_URL=/rsdk/$po_lang/ \
             MDBOOK_OUTPUT__HTML__REDIRECT='{}' \
-            mdbook build -d book/html/$po_lang
+            mdbook build -d book/$po_lang
+            mv book/$po_lang/html book/html/$po_lang
             echo "::endgroup::"
           done
       - name: Setup Pages


### PR DESCRIPTION
resolves #11 
https://radxaos-sdk.github.io/rsdk/zh-CN/html/index.html可正常访问中文文档
但是英文文档指定的路径是https://radxaos-sdk.github.io/rsdk/zh-CN/index.html