### PR TITLE
fix: limit gdm3 to Amlogic SoCs when building bookworm

### DIFF
--- a/src/share/rsdk/build/mod/packages/kde.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/kde.libjsonnet
@@ -1,6 +1,7 @@
 local distro_check = import "../../../configs/distro_check.libjsonnet";
 local desktop_packages = import "categories/desktop.libjsonnet";
 local product_soc = import "../../../configs/product_soc.libjsonnet";
+local soc_family = import "../../../configs/soc_family.libjsonnet";
 local gdm = import "gdm.libjsonnet";
 
 function(suite,
@@ -86,10 +87,11 @@ else
         []
 ),
     },
-} + (if suite == "bookworm" && std.startsWith(product_soc(product), "rk358")
+} + (if std.startsWith(product_soc(product), "rk358") || std.startsWith(soc_family(product_soc(product)), "amlogic") && suite == "bookworm"
 then
     // Debian 12's sddm has issue handling screen hotplug, as well as screen wake up
     // https://applink.feishu.cn/client/message/link/open?token=AmY%2FRdMxxQABZoS475OOwAQ%3D
+    // https://vamrs.feishu.cn/sheets/IFXSs271ThaBVytTCVbcMcxsnpc?sheet=0KtklS&rangeId=0KtklS_iOZ0zYhC18&rangeVer=1
     gdm()
 else
     {}


### PR DESCRIPTION
https://vamrs.feishu.cn/sheets/IFXSs271ThaBVytTCVbcMcxsnpc?sheet=0KtklS&rangeId=0KtklS_iOZ0zYhC18&rangeVer=1