### PR TITLE
feat: enabled some input driver supports

### DIFF
--- a/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
+++ b/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa common kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa.config | 990 ++++++++++++++++++++++++++++
- 1 file changed, 990 insertions(+)
+ src/arch/arm64/configs/radxa.config | 996 ++++++++++++++++++++++++++++
+ 1 file changed, 996 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa.config
 
 diff --git a/src/arch/arm64/configs/radxa.config b/src/arch/arm64/configs/radxa.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..f5bca1bdaf69
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa.config
-@@ -0,0 +1,990 @@
+@@ -0,0 +1,996 @@
 +# KEYBOARD_GPIO_POLLED: Used by Radxa Zero 2's power button
 +CONFIG_KEYBOARD_GPIO_POLLED=m
 +
@@ -905,8 +905,14 @@ index 000000000000..f5bca1bdaf69
 +CONFIG_DRM_PANEL_SITRONIX_ST7789V=m
 +CONFIG_DRM_PANEL_SITRONIX_ST7789V=m
 +
-+# Enable TI ADS7846 touch panel
++# Enable input touchscreen support
++CONFIG_INPUT_TOUCHSCREEN=y
 +CONFIG_TOUCHSCREEN_ADS7846=m
++CONFIG_TOUCHSCREEN_GOODIX=m
++
++# Enable user level input driver support
++CONFIG_INPUT_MISC=y
++CONFIG_INPUT_UINPUT=m
 +
 +# Enable General filesystem local caching manager
 +CONFIG_FSCACHE=m


### PR DESCRIPTION
1. `CONFIG_TOUCHSCREEN_GOODIX` for radxa-display-8hd touch support

2. `CONFIG_INPUT_UINPUT` for some remote app and virtualkeyboard support