### PR TITLE
fix: simplify condition for systemd-boot installation

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/core.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/core.libjsonnet
@@ -88,7 +88,7 @@ else
                 mkdir -p "$1/boot/efi"
                 mount -t tmpfs rsdk "$1/boot/efi"
             |||,
-(if suite == "bookworm" && (std.extVar("sdboot") || product_firmware_type(product) == "edk2")
+(if std.extVar("sdboot") || product_firmware_type(product) == "edk2"
 then
             |||
                 set -e


### PR DESCRIPTION
Some suites (such as noble) cannot build images containing systemd-boot normally under this condition.

https://applink.feishu.cn/client/message/link/open?token=AmiVkUHXA8ACaJ6RWJLAgAQ%3D