### PR TITLE
feat: add support for extra PPA configuration

### DIFF
--- a/src/share/rsdk/build/mod/additional_repos.libjsonnet
+++ b/src/share/rsdk/build/mod/additional_repos.libjsonnet
@@ -2,6 +2,7 @@ local soc_family = import "../../configs/soc_family.libjsonnet";
 local product_soc = import "../../configs/product_soc.libjsonnet";
 local soc_specific_repo = import "../../configs/soc_specific_repo.libjsonnet";
 local product_soc_family(product) = soc_family(product_soc(product));
+local extra_ppa = import "../../configs/extra_ppa.libjsonnet";
 local vscodium = import "vscodium.libjsonnet";
 
 local radxa_url(radxa_mirror) = (
@@ -74,6 +75,24 @@ function(suite, radxa_mirror, radxa_repo_suffix, product, temp_dir, install_vsco
                     suite: suite + radxa_repo_suffix,
                 },
         ],
+        "essential-hooks"+: [
+            |||
+                APT_CONFIG="$MMDEBSTRAP_APT_CONFIG" \
+                apt-get install -oDPkg::Chroot-Directory="$1" -y \
+                software-properties-common
+            |||
+        ] + (if std.length(extra_ppa(product)) > 0
+        then
+        [
+            |||
+                chroot $1 add-apt-repository -y -n "ppa:%(ppa)s"
+            ||| % {
+                ppa: ppa,
+            } for ppa in extra_ppa(product)
+        ]
+        else 
+            []
+        ),
         "customize-hooks"+: [
             |||
                 set -e

--- a/src/share/rsdk/configs/extra_ppa.libjsonnet
+++ b/src/share/rsdk/configs/extra_ppa.libjsonnet
@@ -1,0 +1,20 @@
+local product_soc = import "product_soc.libjsonnet";
+local soc_list = import "socs.json";
+
+function(product)
+  local soc = product_soc(product);
+  local matching_families = [
+    family
+    for family in soc_list
+    if std.member(family.soc_list, soc)
+  ];
+  
+  if std.length(matching_families) > 0 then
+    local family = matching_families[0];
+    
+    if std.objectHas(family, "extra_ppa") then
+      family.extra_ppa
+    else
+      []
+  else
+    []


### PR DESCRIPTION
There are currently no models that can be added to the main branch, but modifications to `socs.json` can be added to the pull request https://github.com/RadxaOS-SDK/rsdk/pull/69. The specific format of the `socs.json` modification is as follows, with the `extra_ppa` field added:

```
    {
        "soc_family": "qualcomm",
        "partition_table_type": "gpt",
        "firmware_type": "edk2",
        "soc_list": [
            "qcs6490"
        ],
        "soc_specific_repo": [
            "qcs6490"
        ],
        "extra_ppa": [
            "ubuntu-qcom-iot/qcom-ppa"
        ]
    }
```