### PR TITLE
fix: desktop-base conflicts with kubuntu-desktop-settings on noble

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/desktop.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/desktop.libjsonnet
@@ -22,7 +22,6 @@ function(suite,
             "breeze-cursor-theme",
             "clinfo",
             "cups",
-            "desktop-base",
             "fonts-noto-cjk",
             "fprintd",
             "fwupd",
@@ -89,6 +88,15 @@ else
         [
             "xiccd",
         ]
+) + 
+
+(if suite != "noble"
+then
+        [
+            "desktop-base",
+        ]
+else
+        []
 ),
     },
 }


### PR DESCRIPTION
When kubuntu-settings-desktop and desktop-base are installed at the same time, the following error will occur:

```
The following packages have unmet dependencies:
 kubuntu-settings-desktop : Conflicts: desktop-base but 12.0.6+nmu1ubuntu1 is to be installed
E: Unable to correct problems, you have held broken packages.
```

References: https://bugs.launchpad.net/ubuntu/+source/desktop-base/+bug/2031887