### PR TITLE
fix: run apt update after add apt repository

### DIFF
--- a/src/share/rsdk/build/mod/additional_repos.libjsonnet
+++ b/src/share/rsdk/build/mod/additional_repos.libjsonnet
@@ -102,7 +102,12 @@ function(suite, radxa_mirror, radxa_repo_suffix, product, temp_dir, install_vsco
         ]
         else 
             []
-        ),
+        ) + [
+            |||
+                APT_CONFIG="$MMDEBSTRAP_APT_CONFIG" \
+                apt-get update -oDPkg::Chroot-Directory="$1"
+            |||,
+        ],
         "customize-hooks"+: [
             |||
                 set -e


### PR DESCRIPTION
在 add-apt-repository 后如果不进行 apt update 更新，不会更新 apt 源的内容，会导致依赖这些源的软件包无法被安装，表现为
 `E: Package 'xxx-package' has no installation candidate`；但给 add-apt-repository 添加 -n 参数也是必须的，因为当前 chroot 状态下还未安装 gpg 公钥，去掉 -n 等同于在 chroot 下跑 apt update，在 chroot 下更新仓库会有 gpg 公钥报错。

fix: https://github.com/RadxaOS-SDK/rsdk/actions/runs/17486947178/job/49671888289#step:3:12677