### PR TITLE
feat: include util-linux-extra

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
@@ -54,6 +54,7 @@ else
             "python3-pip",
             "software-properties-common",
             "tmux",
+            "util-linux-extra",
             "vim",
             "wget",
             "xz-utils",


### PR DESCRIPTION
类似 hwclock 的命令需要安装此包。在 debian 上，util-linux 依赖 util-linux-extra，但在 ubuntu 上没有这层依赖，不会自动安装。