### PR TITLE
fix: include util-linux-extra only on noble and bookworm

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
@@ -54,12 +54,20 @@ else
             "python3-pip",
             "software-properties-common",
             "tmux",
-            "util-linux-extra",
             "vim",
             "wget",
             "xz-utils",
             "zstd",
         ] +
+
+(if suite == "bookworm" || suite == "noble"
+then
+        [
+            "util-linux-extra",
+        ]
+else
+        []
+) +
 
         [
             // Network


### PR DESCRIPTION
util-linux-extra 仅在 debian>=bookworm 与 ubuntu>=noble 时提供。

Bookworm: https://packages.debian.org/search?suite=bookworm&searchon=names&keywords=util-linux-extra
Noble: https://packages.ubuntu.com/search?suite=noble&searchon=names&keywords=util-linux-extra

fix: https://github.com/RadxaOS-SDK/rsdk/actions/runs/17641022875/job/50132330286#step:3:16758