### PR TITLE
fix: check/initialize before modifying .rsdk.json

### DIFF
--- a/src/libexec/rsdk/rsdk-config
+++ b/src/libexec/rsdk/rsdk-config
@@ -57,6 +57,11 @@ main() {
 	2)
 		local RSDK_TEMP_JSON VALUE="$2"
 		RSDK_TEMP_JSON="$(mktemp)"
+
+		if ! [[ -f .rsdk.json ]]; then
+			echo "{}" > .rsdk.json
+		fi
+
 		jq -er --arg field "$FIELD" --arg value "$VALUE" 'setpath($field / "."; $value)' .rsdk.json >"$RSDK_TEMP_JSON"
 		mv "$RSDK_TEMP_JSON" .rsdk.json
 		;;


### PR DESCRIPTION
Otherwise jq will throw an error when .rsdk.json does not exist:
```
vscode ➜ /workspaces/rsdk (main) $ rsdk config infra.organizations.package CodeChenL
jq: error: Could not open file .rsdk.json: No such file or directory
```