### PR TITLE
fix: Set legacy_boot flag without enabling ESP on GPT partitions

### DIFF
--- a/src/share/rsdk/build/image.jsonnet
+++ b/src/share/rsdk/build/image.jsonnet
@@ -42,6 +42,7 @@ then
     part-set-bootable /dev/sda 2 true
     part-add /dev/sda primary 679936 -34
     part-set-bootable /dev/sda 3 true
+    part-set-gpt-guid /dev/sda 3 8300
 |||
 else
 |||


### PR DESCRIPTION
在 GPT 分区上使用 part-set-bootable 将默认自动设置 legacy_boot 和 esp 标志. 如果该分区不打算用作 EFI 系统分区, 则此行为可能会干扰 UEFI 启动预期.