### PR TITLE
Revert "fix: Set legacy_boot flag without enabling ESP on GPT partitions"

### DIFF
--- a/src/share/rsdk/build/image.jsonnet
+++ b/src/share/rsdk/build/image.jsonnet
@@ -42,7 +42,6 @@ then
     part-set-bootable /dev/sda 2 true
     part-add /dev/sda primary 679936 -34
     part-set-bootable /dev/sda 3 true
-    part-set-gpt-guid /dev/sda 3 8300
 |||
 else
 |||


### PR DESCRIPTION
Reverts RadxaOS-SDK/rsdk#106

Build fail: https://github.com/radxa-build/radxa-dragon-q6a/actions/runs/18591747690/job/53008126770