### PR TITLE
fix: Set legacy_boot flag without enabling ESP on GPT partitions

### DIFF
--- a/src/share/rsdk/build/image.jsonnet
+++ b/src/share/rsdk/build/image.jsonnet
@@ -53,6 +53,7 @@ else
 then
 |||
     part-set-gpt-type /dev/sda 2 C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+    part-set-gpt-type /dev/sda 3 0FC63DAF-8483-4772-8E79-3D69D8477DE4
     part-set-gpt-attributes /dev/sda 2 4
     part-set-gpt-attributes /dev/sda 3 4
 |||


### PR DESCRIPTION
在 GPT 分区上使用 part-set-bootable 将默认自动设置 legacy_boot 和 esp 标志. 如果该分区不打算用作 EFI 系统分区, 则此行为可能会干扰 UEFI 启动预期.

Link: https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs