### PR TITLE
feat：q6a radxaos use gdm3 as default display manager

### DIFF
--- a/src/share/rsdk/build/mod/packages/kde.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/kde.libjsonnet
@@ -89,7 +89,7 @@ else
         ]
 ),
     },
-} + (if suite == "bookworm"
+} + (if suite == "bookworm" || suite == "noble"
 then
     // Debian 12's sddm has issue handling screen hotplug, as well as screen wake up
     // https://applink.feishu.cn/client/message/link/open?token=AmY%2FRdMxxQABZoS475OOwAQ%3D


### PR DESCRIPTION
sddm dose not support hotplug when pluging external monitor， which cause black screen issues. maybe gdm3 works better in this case