### PR TITLE
fix: add zstd package in essential hooks

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
@@ -58,7 +58,6 @@ else
             "vim",
             "wget",
             "xz-utils",
-            "zstd",
         ] +
 
 (if suite == "bookworm" || suite == "noble"

--- a/src/share/rsdk/build/mod/packages/categories/core.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/core.libjsonnet
@@ -85,7 +85,7 @@ else
 
                 APT_CONFIG="$MMDEBSTRAP_APT_CONFIG" \
                 apt-get install -oDPkg::Chroot-Directory="$1" -y \
-                rsetup radxa-bootutils python-is-python3 initramfs-tools
+                rsetup radxa-bootutils python-is-python3 initramfs-tools zstd
 
                 mkdir -p "$1/boot/efi"
                 mount -t tmpfs rsdk "$1/boot/efi"


### PR DESCRIPTION
fix `/usr/sbin/dkms: line 1154: zstd: command not found`

log: https://github.com/radxa-build/radxa-dragon-q6a/actions/runs/18756108590/job/53508440534#step:3:11638