### PR TITLE
feat: enable Loopback device and Device mapper support

### DIFF
--- a/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
+++ b/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa common kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa.config | 1032 ++++++++++++++++++++++++++++
- 1 file changed, 1032 insertions(+)
+ src/arch/arm64/configs/radxa.config | 1037 ++++++++++++++++++++++++++++
+ 1 file changed, 1037 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa.config
 
 diff --git a/src/arch/arm64/configs/radxa.config b/src/arch/arm64/configs/radxa.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..f5bca1bdaf69
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa.config
-@@ -0,0 +1,1032 @@
+@@ -0,0 +1,1037 @@
 +# Enable FPDT on supported platforms
 +CONFIG_ACPI_FPDT=y
 +
@@ -1047,5 +1047,10 @@ index 000000000000..f5bca1bdaf69
 +CONFIG_IP_ADVANCED_ROUTER=y
 +CONFIG_IP_MULTIPLE_TABLES=y
 +CONFIG_IPV6_MULTIPLE_TABLES=y
++
++# Enable Loopback device and Device mapper support
++CONFIG_MD=y
++CONFIG_BLK_DEV_LOOP=m
++CONFIG_BLK_DEV_DM=m
 -- 
 2.47.1


### PR DESCRIPTION
Support for using `partx` or `kpartx` to map local images.