### PR TITLE
feat: Add vulkan-driver

### DIFF
--- a/src/share/rsdk/build/mod/packages/kde.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/kde.libjsonnet
@@ -71,6 +71,7 @@ then
         [
             "plasma-workspace-wayland",
             "qml-module-org-kde-pipewire",
+            "mesa-vulkan-drivers",
         ]
 else
         []


### PR DESCRIPTION
Vulkan 性能测试，如 vkpeak 需要依赖 mesa-vulkan-driver 
https://applink.feishu.cn/client/message/link/open?token=Ami%2ByZSflQABaS5U0grCS9I%3D
