### PR TITLE
feat: enable UTF8 in native language support

### DIFF
--- a/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
+++ b/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] feat: Radxa common kernel config
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
  src/arch/arm64/configs/radxa.config | 1046 ++++++++++++++++++++++++++++
- 1 file changed, 1046 insertions(+)
+ 1 file changed, 1047 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa.config
 
 diff --git a/src/arch/arm64/configs/radxa.config b/src/arch/arm64/configs/radxa.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..f5bca1bdaf69
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa.config
-@@ -0,0 +1,1046 @@
+@@ -0,0 +1,1047 @@
 +# Enable FPDT on supported platforms
 +CONFIG_ACPI_FPDT=y
 +
@@ -965,6 +965,7 @@ index 000000000000..f5bca1bdaf69
 +# Enable additional language support
 +CONFIG_NLS_ASCII=y
 +CONFIG_NLS_ISO8859_1=y
++CONFIG_NLS_UTF8=y
 +
 +# Necessary for Android
 +# https://github.com/sunflower2333/cix_linux/commit/42264e5a6d8ac025dfe8d20a632a72cf3719e37f


### PR DESCRIPTION
Otherwise, filenames containing CJK characters in the mounted SMB drive will be displayed as garbled text, or the mounting will fail if UTF8 is requested.