### PR TITLE
chore(Q6A,Q900): switch desktop to GNOME

### DIFF
--- a/src/share/rsdk/configs/products.json
+++ b/src/share/rsdk/configs/products.json
@@ -337,7 +337,7 @@
         "soc": "qcs6490",
         "sector_size": [512, 4096],
         "supported_suite": ["noble"],
-        "supported_edition": ["kde"]
+        "supported_edition": ["gnome"]
     },
     {
         "product": "radxa-airbox-q900",
@@ -346,6 +346,6 @@
         "soc": "qcs9075",
         "sector_size": [512, 4096],
         "supported_suite": ["noble"],
-        "supported_edition": ["kde"]
+        "supported_edition": ["gnome"]
     }
 ]


### PR DESCRIPTION
Qualcomm GPU 会在 KDE Wayland 桌面上无法正常使用热插拔, 拔下显示器重新插入后画面冻结, 系统正常运行. 在使用 GNOME 桌面或者不进入桌面的情况下热插拔正常, 在对比 zero 2  Mali GPU 使用的 KDE Wayland 桌面热插拔正常. 其他适配系统, Armbian 与 Fedroa 在 Q6A、Q900 开发板使用 KDE Wayland 桌面也是相同的 UI 冻结. 并且 KDE Wayland 在不同显卡(AMD、Intel、Nvidia) 下的表现并不相同，故认为 KDE Wayland 桌面与 Qualcomm GPU 兼容性不好. 该热插拔 BUG 影响桌面的正常使用, 需要切换 GNOME 桌面. 在 Q6A、Q900 开发板上已验证在 GNOME 桌面上热插拔, 1080p、2k、4k 屏输出, 自动登录等功能正常，暂未发现其他影响桌面功能使用的 BUG.