### PR TITLE
feat: support building with Debian / Ubuntu snapshot services

### DIFF
--- a/src/libexec/rsdk/rsdk-build
+++ b/src/libexec/rsdk/rsdk-build
@@ -53,6 +53,10 @@ generate_rootfs() {
 		JSONNET_ARGS+=("--tla-str" "distro_mirror=$RSDK_OPTION_DISTRO_MIRROR")
 	fi
 
+	if [[ -n ${RSDK_OPTION_SNAPSHOT_TIMESTAMP} ]]; then
+		JSONNET_ARGS+=("--tla-str" "snapshot_timestamp=$RSDK_OPTION_SNAPSHOT_TIMESTAMP")
+	fi
+
 	if [[ -n ${RSDK_OPTION_RADXA_MIRROR} ]]; then
 		JSONNET_ARGS+=("--tla-str" "radxa_mirror=$RSDK_OPTION_RADXA_MIRROR")
 	fi
@@ -177,7 +181,7 @@ main() {
 	source "$SCRIPT_DIR/../../lib/rsdk/utils.sh"
 
 	local TEMP
-	if ! TEMP="$(getopt -o "hdPTm:M:i:k:f:p:s:" -l "no-efi,help,debug,dry-run,no-pkgs-json,test-repo,mirror:,image-name:,no-cache,override-kernel:,override-firmware:,override-product:,no-vendor-packages,debs:,sdboot,sector-size:" -n "$0" -- "$@")"; then
+	if ! TEMP="$(getopt -o "hdPTm:M:i:k:f:p:s:" -l "no-efi,help,debug,dry-run,no-pkgs-json,test-repo,mirror:,image-name:,no-cache,override-kernel:,override-firmware:,override-product:,no-vendor-packages,debs:,sdboot,sector-size:,snapshot:" -n "$0" -- "$@")"; then
 		return
 	fi
 	eval set -- "$TEMP"
@@ -186,6 +190,7 @@ main() {
 	local RSDK_OPTION_DEBUG="${RSDK_OPTION_DEBUG:-false}"
 	local RSDK_OPTION_REPO_SUFFIX="${RSDK_OPTION_REPO_SUFFIX:-}"
 	local RSDK_OPTION_DISTRO_MIRROR="${RSDK_OPTION_DISTRO_MIRROR:-}"
+	local RSDK_OPTION_SNAPSHOT_TIMESTAMP="${RSDK_OPTION_SNAPSHOT_TIMESTAMP:-}"
 	local RSDK_OPTION_RADXA_MIRROR="${RSDK_OPTION_RADXA_MIRROR:-}"
 	local RSDK_OPTION_ROOTFS="${RSDK_OPTION_ROOTFS:-rootfs.tar}"
 	local RSDK_OPTION_IMAGE_NAME="${RSDK_OPTION_IMAGE_NAME:-$("$SCRIPT_DIR/../../bin/rsdk" config build.default_image_name)}"
@@ -225,6 +230,10 @@ main() {
 			;;
 		-m | --mirror)
 			RSDK_OPTION_DISTRO_MIRROR="$1"
+			shift
+			;;
+		--snapshot)
+			RSDK_OPTION_SNAPSHOT_TIMESTAMP="$1"
 			shift
 			;;
 		-M)
@@ -284,6 +293,13 @@ main() {
 	local PRODUCT="${1}" SUITE EDITION
 	if ! jq -er --arg product "$PRODUCT" '.[] | select(.product == $product)' "$SCRIPT_DIR/../../share/rsdk/configs/products.json" &>/dev/null; then
 		echo "'$PRODUCT' is not a supported product." >&2
+		return 1
+	fi
+
+	# If '--snapshot' and '-m | --mirror' switch on at the same time, exit
+	# with error because they are not compatible
+	if [[ -n $RSDK_OPTION_SNAPSHOT_TIMESTAMP ]] && [[ -n $RSDK_OPTION_DISTRO_MIRROR ]]; then
+		echo "You can not use snapshot when using custom Debian / Ubuntu archive mirror." >&2
 		return 1
 	fi
 

--- a/src/libexec/rsdk/rsdk-help
+++ b/src/libexec/rsdk/rsdk-help
@@ -37,6 +37,10 @@ Build RadxaOS system image.
         Build using Radxa APT test archives.
     -m | --mirror <mirror_url>
         Specify custom Debian / Ubuntu archive mirror URL.
+    --snapshot <timestamp>
+        Build using Debian / Ubuntu snapshot archive.
+        A timestamp is required. Ex: 20260105T082626Z.
+        This is incompatible with '-m | --mirror <mirror_url>'.
     -M <mirror_url>
         Specify custom non-Debian non-Ubuntu archive mirror URL. This mirror should
         serve both Radxa archives as well as any other 3rd party archives.

--- a/src/share/rsdk/build/mod/distro.libjsonnet
+++ b/src/share/rsdk/build/mod/distro.libjsonnet
@@ -1,23 +1,49 @@
 local distro_check = import "../../configs/distro_check.libjsonnet";
 
-local distro_base(suite, distro_mirror, distro, architecture, distro_mirror_default) = {
+local mirror_link(
+    distro_mirror,
+    snapshot_timestamp,
+    distro,
+    architecture,
+    distro_mirror_default,
+    snapshot_mirror_default
+) = if snapshot_timestamp != ""
+then
+    // Build with snapshot service
+    snapshot_mirror_default + snapshot_timestamp
+else
+    (if distro_mirror == ""
+     then
+         // Primary archive
+         distro_mirror_default
+     else
+         distro_mirror) + "/" +
+     (if distro == "ubuntu" && architecture != "amd64"
+      then
+          distro + "-ports"
+      else
+          distro);
+
+local distro_base(
+    suite,
+    distro_mirror,
+    distro,
+    architecture,
+    snapshot_timestamp,
+    distro_mirror_default,
+    snapshot_mirror_default,
+) = {
     mmdebstrap+: {
         components+: [
             "main",
         ],
         mirrors+: [
-            // Primary archive
-            (if distro_mirror == ""
-            then
-                distro_mirror_default
-            else
-                distro_mirror)
-                + "/" +
-            (if distro == "ubuntu" && architecture != "amd64"
-            then
-                distro + "-ports"
-            else
-                distro),
+            mirror_link(distro_mirror,
+                        snapshot_timestamp,
+                        distro,
+                        architecture,
+                        distro_mirror_default,
+                        snapshot_mirror_default),
         ],
         "setup-hooks"+: [
             |||
@@ -26,7 +52,7 @@ local distro_base(suite, distro_mirror, distro, architecture, distro_mirror_defa
                 # backports archive
                 head -n 1 "$1/etc/apt/sources.list" | sed -E -e "s/(%(suite)s)/\\1-backports/" > "$1/etc/apt/sources.list.d/50-%(suite)s-backports.list"
                 # security archive
-                head -n 1 "$1/etc/apt/sources.list" | sed -E -e "s/(%(suite)s)/\\1-security/" -e "s|/debian |/debian-security |" > "$1/etc/apt/sources.list.d/50-%(suite)s-security.list"
+                head -n 1 "$1/etc/apt/sources.list" | sed -E -e "s/(%(suite)s)/\\1-security/" -e "s|/debian|/debian-security|" > "$1/etc/apt/sources.list.d/50-%(suite)s-security.list"
                 # main archive
                 mv "$1/etc/apt/sources.list" "$1/etc/apt/sources.list.d/50-%(suite)s.list"
             ||| % {
@@ -53,8 +79,9 @@ local distro_debian(
     suite,
     distro_mirror,
     architecture,
+    snapshot_timestamp,
     distro = "debian",
-) = distro_base(suite, distro_mirror, distro, architecture, "https://deb.debian.org") + {
+) = distro_base(suite, distro_mirror, distro, architecture, snapshot_timestamp, "https://deb.debian.org", "https://snapshot.debian.org/archive/debian/") + {
     mmdebstrap+: {
         components+: std.prune([
             "contrib",
@@ -68,8 +95,9 @@ local distro_ubuntu(
     suite,
     distro_mirror,
     architecture,
+    snapshot_timestamp,
     distro = "ubuntu",
-) = distro_base(suite, distro_mirror, distro, architecture, "http://ports.ubuntu.com") + {
+) = distro_base(suite, distro_mirror, distro, architecture, snapshot_timestamp, "http://ports.ubuntu.com", "https://snapshot.ubuntu.com/ubuntu/") + {
     mmdebstrap+: {
         components+: [
             "restricted",
@@ -79,10 +107,10 @@ local distro_ubuntu(
     }
 };
 
-function(suite, distro_mirror, architecture)
+function(suite, distro_mirror, architecture, snapshot_timestamp)
     if distro_check(suite) == "debian"
     then
-        distro_debian(suite, distro_mirror, architecture)
+        distro_debian(suite, distro_mirror, architecture, snapshot_timestamp)
     else if distro_check(suite) == "ubuntu"
     then
-        distro_ubuntu(suite, distro_mirror, architecture)
+        distro_ubuntu(suite, distro_mirror, architecture, snapshot_timestamp)

--- a/src/share/rsdk/build/rootfs.jsonnet
+++ b/src/share/rsdk/build/rootfs.jsonnet
@@ -14,6 +14,7 @@ function(
     rsdk_rev = "",
 
     distro_mirror = "",
+    snapshot_timestamp = "",
 
     radxa_mirror = "",
     radxa_repo_suffix = "",
@@ -28,7 +29,7 @@ function(
     firmware_override = "",
     install_vscodium = false,
     use_pkgs_json = true,
-) distro(suite, distro_mirror, architecture)
+) distro(suite, distro_mirror, architecture, snapshot_timestamp)
 + additional_repos(suite, radxa_mirror, radxa_repo_suffix, product, temp_dir, install_vscodium, use_pkgs_json)
 + packages(suite, edition, product, temp_dir, vendor_packages, linux_override, firmware_override)
 + cleanup()


### PR DESCRIPTION
 这个PR目前算是一个`proof-of-concept`，目前修改只支持Debian。
这样修改的话就能够直接把snapshot的url通过`-m`传给rsdk使用，比如：
```
-m https://snapshot.debian.org/archive/debian/20260101T022824Z/
```
不过因为发现Ubuntu使用snapshot的方法[[0]]跟Debian有些不太一样所以有些犹豫了，会不会多设置一个`--snapshot`命令更好一些？

[0]: https://snapshot.ubuntu.com/