### PR TITLE
fix: linux: common: enable  CRC32/CRC64 functions

### DIFF
--- a/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
+++ b/src/share/rsdk/infra-package/debian/patches/linux/0001-feat-Radxa-common-kernel-config.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] feat: Radxa common kernel config
 
 Signed-off-by: ZHANG Yuntian <yt@radxa.com>
 ---
- src/arch/arm64/configs/radxa.config | 1064 +++++++++++++++++++++++++++
- 1 file changed, 1064 insertions(+)
+ src/arch/arm64/configs/radxa.config | 1069 +++++++++++++++++++++++++++
+ 1 file changed, 1069 insertions(+)
  create mode 100644 src/arch/arm64/configs/radxa.config
 
 diff --git a/src/arch/arm64/configs/radxa.config b/src/arch/arm64/configs/radxa.config
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000000..f5bca1bdaf69
 --- /dev/null
 +++ b/src/arch/arm64/configs/radxa.config
-@@ -0,0 +1,1064 @@
+@@ -0,0 +1,1069 @@
 +# Enable FPDT on supported platforms
 +CONFIG_ACPI_FPDT=y
 +
@@ -682,6 +682,11 @@ index 000000000000..f5bca1bdaf69
 +CONFIG_CRYPTO_LZ4=m
 +CONFIG_CRYPTO_LZ4HC=m
 +CONFIG_CRYPTO_ZSTD=m
++
++# Enable CRC checksum algorithm
++# Required when loading certain compression kernel modules
++CONFIG_CRC32=m
++CONFIG_CRC64=m
 +
 +# Enable ZRAM
 +CONFIG_ZSMALLOC=m


### PR DESCRIPTION
To support for loading out-tree modules