### PR TITLE
feat: add radxa-dragon-qcs9075 support

### DIFF
--- a/src/share/rsdk/configs/products.json
+++ b/src/share/rsdk/configs/products.json
@@ -709,5 +709,23 @@
         "supported_edition": [
             "gnome"
         ]
+    },
+    {
+        "product": "radxa-dragon-qcs9075",
+        "product_name": "Radxa Dragon QCS9075",
+        "product_full_name": "Radxa Dragon QCS9075",
+        "soc": [
+            "qcs9075"
+        ],
+        "sector_size": [
+            512,
+            4096
+        ],
+        "supported_suite": [
+            "noble"
+        ],
+        "supported_edition": [
+            "gnome"
+        ]
     }
 ]


### PR DESCRIPTION
给 qcs8075 的主控统一使用的镜像