### PR TITLE
feat: remove android-tools-adbd from base packages

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
@@ -113,7 +113,6 @@ else
 
         [
             // Radxa
-            "android-tools-adbd",
             "libreelec-alsa-utils",
             "radxa-otgutils",
         ] +


### PR DESCRIPTION
    feat: remove android-tools-adbd from base packages
    
    The *adbd* packages should be installed as the dependency of radxa-otgutils[0].
    
    [0]: https://github.com/radxa-pkg/radxa-otgutils/blob/f91fa37fd6387e6980f44780f940b18bbdfd28fe/debian/control#L17-L18