### PR TITLE
feat: add adbd/bookworm-backports

### DIFF
--- a/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
+++ b/src/share/rsdk/build/mod/packages/categories/base.libjsonnet
@@ -111,6 +111,13 @@ else
             "usbutils",
         ] +
 
+(if suite == "bookworm"
+then
+        [
+            "adbd/bookworm-backports",
+        ]
+) +
+
         [
             // Radxa
             "libreelec-alsa-utils",


### PR DESCRIPTION
    feat: add adbd/bookworm-backports
    
    On O6N running this image[0], connecting the Type-C port to a host
    machine and enabing the adb service using rsetup[1]; when a USB2.0 cable
    is used, the host machine can detect the O6N as an adb device, but it's
    not the case with a USB3.0 cable. When a USB3.0 cable is used, the
    GNU/Linux host machine kernel message shows:
    ```
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    usb 2-8.4: new SuperSpeed USB device number 16 using xhci_hcd
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    usb 2-8-port4: attempt power cycle
    usb 2-8.4: new SuperSpeed USB device number 17 using xhci_hcd
    usb 2-8.4: no configurations
    usb 2-8.4: can't read configurations, error -22
    ```
    The issue can be solved by updating adbd to the one presents in Debian
    bookworm-backports[2]. Because the adbd package is in bookworm-backports,
    it can only be installed by explicitly saying installing the adbd package
    from bookworm-backports:
    ```
    apt install adbd/bookworm-backports
    ```
    
    [0]: https://github.com/radxa-build/radxa-orion-cix-p1/releases/download/rsdk-t4/radxa-orion-cix-p1_bookworm_gnome_t4.output_512.img.xz
    [1]: https://docs.radxa.com/template/sbc/os-config/rsetup#usb-otg-services
    [2]: https://packages.debian.org/bookworm-backports/adbd