### PR TITLE
fix: resolve devcontainer startup hang and Nix package installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,19 +5,18 @@
   "packages": {
     "": {
       "dependencies": {
-        "@devcontainers/cli": "^0.72.0"
+        "@devcontainers/cli": "^0.86.0"
       }
     },
     "node_modules/@devcontainers/cli": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.72.0.tgz",
-      "integrity": "sha512-vDv33/I5POw1wDJmcMbOCTWd3xTk4bbVruJ9Qgr5eiLSl1OsfufN5WfeTZqgK1HeqrNqtH/xPyCKB2LXDNIv3w==",
-      "license": "MIT",
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.86.0.tgz",
+      "integrity": "sha512-xfc1pc1wYrPkRpFi3bsYKz2F8VGiPVwISe11I6Tl2o0gqDB2LCMI6yT5mmZ+8v2e5ff+x/lbHIVCEThoLJJS8Q==",
       "bin": {
         "devcontainer": "devcontainer.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": ">=20.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@devcontainers/cli": "^0.72.0"
+    "@devcontainers/cli": "^0.86.0"
   }
 }

--- a/src/libexec/rsdk/rsdk-devcon
+++ b/src/libexec/rsdk/rsdk-devcon
@@ -1,5 +1,47 @@
 #!/usr/bin/env bash
 
+find_devcontainer_id() {
+	local RSDK_ROOT="$1"
+	docker ps -a -q --filter "label=devcontainer.local_folder=$RSDK_ROOT" | head -1
+}
+
+is_container_running() {
+	local cid="$1"
+	[[ -n "$cid" ]] && [[ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" == "true" ]]
+}
+
+devcon_exec() {
+	local RSDK_ROOT="$1"
+	local max_retries=3
+	local retry_delay=5
+	local attempt=1
+
+	while [[ $attempt -le $max_retries ]]; do
+		local cid
+		cid="$(find_devcontainer_id "$RSDK_ROOT")"
+
+		if is_container_running "$cid"; then
+			devcontainer exec --workspace-folder "$RSDK_ROOT" bash
+			return $?
+		fi
+
+		if [[ $attempt -lt $max_retries ]]; then
+			echo "Waiting for devcontainer to be ready (attempt $attempt/$max_retries)..." >&2
+			sleep "$retry_delay"
+		fi
+		((attempt++))
+	done
+
+	echo "Devcontainer is not running after $max_retries attempts." >&2
+	if [[ -n "$cid" ]]; then
+		echo "Container $cid exists but is not running. Check logs:" >&2
+		echo "  docker logs --tail 50 $cid" >&2
+	else
+		echo "No devcontainer found. Try running 'rsdk devcon up' first." >&2
+	fi
+	return 1
+}
+
 main() {
 	local SCRIPT_DIR
 	SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -11,20 +53,60 @@ main() {
 		exit 1
 	fi
 
-	local RSDK_ROOT="${DEVENV_ROOT:-$SCRIPT_DIR/../../../}"
+	local RSDK_ROOT
+	RSDK_ROOT="$(realpath "${DEVENV_ROOT:-$SCRIPT_DIR/../../../}")"
 
 	case "${1:-}" in
 	"build")
-		devcontainer "${1:-}" --workspace-folder "$RSDK_ROOT"
+		devcontainer "${1}" --workspace-folder "$RSDK_ROOT"
 		;;
 	"up")
-		devcontainer "${1:-}" --workspace-folder "$RSDK_ROOT" --remove-existing-container
+		shift
+		local up_args=("--workspace-folder" "$RSDK_ROOT")
+		local skip_post=false
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			"--skip-post-create")
+				skip_post=true
+				;;
+			*)
+				echo "Unknown option: $1" >&2
+				;;
+			esac
+			shift
+		done
+		if [[ "$skip_post" == "true" ]]; then
+			up_args+=("--skip-post-create")
+		fi
+		up_args+=("--remove-existing-container")
+		devcontainer up "${up_args[@]}"
+		;;
+	"logs")
+		local cid
+		cid="$(find_devcontainer_id "$RSDK_ROOT")"
+		if [[ -z "$cid" ]]; then
+			echo "No devcontainer found." >&2
+			exit 1
+		fi
+		docker logs --tail 50 "$cid"
+		;;
+	"status")
+		local cid
+		cid="$(find_devcontainer_id "$RSDK_ROOT")"
+		if [[ -z "$cid" ]]; then
+			echo "No devcontainer found."
+		elif is_container_running "$cid"; then
+			echo "Devcontainer is running (${cid:0:12})."
+		else
+			echo "Devcontainer exists but is not running (${cid:0:12})."
+		fi
 		;;
 	"exec" | "")
-		devcontainer exec --workspace-folder "$RSDK_ROOT" bash
+		devcon_exec "$RSDK_ROOT"
 		;;
 	*)
 		echo "Unknown command ${1:-}." >&2
+		echo "Usage: rsdk devcon {up|build|exec|logs|status}" >&2
 		exit 1
 		;;
 	esac

--- a/src/libexec/rsdk/rsdk-setup
+++ b/src/libexec/rsdk/rsdk-setup
@@ -1,31 +1,28 @@
 #!/usr/bin/env bash
 
 rate_limited() {
-	echo "You might be rate limited by GitHub."
-	echo "Please request a PAT from GitHub website, and add it to your Dev Container:"
-	echo "mkdir -p ~/.config/nix/ && echo 'access-tokens = github.com=YOUR_GITHUB_PAT' >> ~/.config/nix/nix.conf && src/bin/rsdk setup"
-	echo "You can run above command in a new terminal once you complete this one."
-	read -rp "Press Enter to continue..."
-	exit 0
+	echo "You might be rate limited by GitHub." >&2
+	echo "Please request a PAT from GitHub website, and add it to your Dev Container:" >&2
+	echo "mkdir -p ~/.config/nix/ && echo 'access-tokens = github.com=YOUR_GITHUB_PAT' >> ~/.config/nix/nix.conf && src/bin/rsdk setup" >&2
+	echo "You can run above command in a new terminal once you complete this one." >&2
+	exit 1
 }
 
 broken_nix_store() {
-	echo "You might have broken devcontainer Nix volume."
-	echo "Please stop and remove your current devcontainer container, then remove the Nix volume."
-	echo "You might need to use following commands:"
-	echo "    docker container ls"
-	echo "    docker container rm -f <devcontainer ID>"
-	echo "    docker volume ls"
-	echo "    docker volume rm <Nix volume>"
-	read -rp "Press Enter to continue..."
-	exit 0
+	echo "You might have broken devcontainer Nix volume." >&2
+	echo "Please stop and remove your current devcontainer container, then remove the Nix volume." >&2
+	echo "You might need to use following commands:" >&2
+	echo "    docker container ls" >&2
+	echo "    docker container rm -f <devcontainer ID>" >&2
+	echo "    docker volume ls" >&2
+	echo "    docker volume rm <Nix volume>" >&2
+	exit 1
 }
 
 broken_devenv_cache() {
-	echo "You might have broken devenv cache."
-	echo "Please reset the content in .devenv and .devcontainer/.devenv."
-	read -rp "Press Enter to continue..."
-	exit 0
+	echo "You might have broken devenv cache." >&2
+	echo "Please reset the content in .devenv and .devcontainer/.devenv." >&2
+	exit 1
 }
 
 get_distro_id() {
@@ -124,10 +121,40 @@ install_devcontainer_cli() {
 }
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+RSDK_ROOT="${DEVENV_ROOT:-$SCRIPT_DIR/../../../}"
 # shellcheck source=src/lib/rsdk/utils.sh
 source "$SCRIPT_DIR/../../lib/rsdk/utils.sh"
 
-if ! command -v direnv || ! command -v devenv; then
+ensure_nix_packages() {
+	if command -v direnv && command -v devenv; then
+		return 0
+	fi
+
+	if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix.sh ]]; then
+		# shellcheck source=/dev/null
+		. /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+	fi
+
+	if command -v direnv && command -v devenv; then
+		return 0
+	fi
+
+	if ! command -v nix-env; then
+		return 1
+	fi
+
+	echo "Installing required Nix packages (direnv, devenv, cachix)..." >&2
+	if ! nix-env -iA nixpkgs.cachix nixpkgs.direnv nixpkgs.devenv; then
+		return 1
+	fi
+
+	if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix.sh ]]; then
+		# shellcheck source=/dev/null
+		. /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+	fi
+}
+
+if ! ensure_nix_packages; then
 	broken_nix_store
 fi
 
@@ -138,7 +165,7 @@ if git status &>/dev/null && [[ -z "$(git submodule status)" ]]; then
 	fi
 fi
 
-direnv allow
+cd "$RSDK_ROOT" && direnv allow
 # shellcheck disable=SC2016
 echo 'eval "$(direnv hook bash)"' >>~/.bashrc
 


### PR DESCRIPTION
## Summary

Fixes #164 — `rsdk devcon up` hangs at "Container started" and never reaches a shell prompt.

## Root Causes

1. **`@devcontainers/cli` v0.72.0 incompatible with Docker 29.x** — `devcontainer up` hangs after "Container started" because the CLI lifecycle management blocks on the `docker run` process. Upgraded to v0.86.0 resolves this.

2. **Nix packages not in active profile** — The `ghcr.io/devcontainers/features/nix:1` feature installs `cachix`, `direnv`, `devenv` to the Nix store but doesn't always add them to the active profile, leaving them out of PATH. Added `ensure_nix_packages()` in `rsdk-setup` to detect and auto-install missing packages.

3. **Blocking `read -rp` in error handlers** — `rsdk-setup`'s error handlers used `read -rp` which hangs during non-interactive `postCreateCommand`. Replaced with stderr output + `exit 1`.

4. **`--privileged` causing container startup issues** — Disabled by default (marked OPTIONAL); uncomment if needed for loop devices.

5. **`RSDK_ROOT` path resolution bug** — Unresolved `../` in path broke Docker label lookups. Fixed with `realpath`.

## Changes

| File | Changes |
|------|---------|
| `package.json` | Upgraded `@devcontainers/cli` from `^0.72` to `^0.86` |
| `src/libexec/rsdk/rsdk-setup` | Removed `read -rp` blocking; added `ensure_nix_packages()` auto-install; fixed `direnv allow` to use repo root |
| `src/libexec/rsdk/rsdk-devcon` | Fixed `RSDK_ROOT` path resolution; added retry logic, `logs`/`status` subcommands, `--skip-post-create` flag |
| `.devcontainer/devcontainer.json` | Disabled `--privileged` and `-v /dev:/dev` (OPTIONAL features) |

## New Commands

```
rsdk devcon status
rsdk devcon logs
rsdk devcon up --skip-post-create
```