### PR TITLE
feat: support glob wildcard matching in pkg.conf

### DIFF
--- a/src/libexec/rsdk/rsdk-infra-pkg-download
+++ b/src/libexec/rsdk/rsdk-infra-pkg-download
@@ -7,7 +7,13 @@ find_target_distros() {
 
 	local requested_json i
 	for i in "$deb" "*"; do
-		if requested_json="$(jq -er --arg target "$i" 'to_entries[] | select(.key == $target).value.Releases' "$pkg_conf")" && [[ $requested_json != "null" ]]; then
+		if requested_json="$(jq -er --arg target "$i" '
+			to_entries[]
+			| select(.key == $target
+				or (.key != "*"
+					and (.key as $k | $target | test($k))))
+			| .value.Releases
+		' "$pkg_conf")" && [[ $requested_json != "null" ]]; then
 			mapfile -t requested < <(jq -er '.[]' <<<"$requested_json") && array_remove "requested" ""
 			array_intersect "${supported[@]}" -- "${requested[@]}"
 			return


### PR DESCRIPTION
Add glob pattern matching as a fallback between exact filename match and the '*' default. Keys in pkg.conf containing '*' (other than the literal '*' key itself) are treated as glob patterns using bash case matching, allowing a single rule to cover multiple related debs.